### PR TITLE
Pass the site id to the chooser and chosen view

### DIFF
--- a/src/wagtail_email_subscription/abstract_models.py
+++ b/src/wagtail_email_subscription/abstract_models.py
@@ -10,7 +10,7 @@ from wagtail.contrib.forms.models import (
     AbstractFormSubmission,
 )
 
-from .chooser.widgets import ListChooserWidget
+from .chooser.panels import FieldPanelWithPage
 from .utils import get_email_subscription_settings
 
 logger = logging.getLogger(__name__)
@@ -103,7 +103,7 @@ class AbstractEmailSubscriptionForm(AbstractForm):
         MultiFieldPanel(
             [
                 FieldPanel("enabled"),
-                FieldPanel("selected_list", widget=ListChooserWidget),
+                FieldPanelWithPage("selected_list"),
             ],
             heading="Email Subscription Settings",
         ),

--- a/src/wagtail_email_subscription/chooser/base.py
+++ b/src/wagtail_email_subscription/chooser/base.py
@@ -1,5 +1,7 @@
-from django.conf.urls import url
+from urllib.parse import urlencode
+
 from django.core.exceptions import ObjectDoesNotExist
+from django.urls import path, re_path
 from generic_chooser.views import ChooserMixin, ChooserViewSet
 from wagtail.core.models import Site
 
@@ -7,8 +9,6 @@ from wagtail_email_subscription.utils import get_email_subscription_settings
 
 
 class EmailSubscriptionChooserMixin(ChooserMixin):
-    # When enabled, you can use the filter_result_by_search_term method to
-    # filter the result 'client side' in the REST result set
     is_searchable = False
     per_page = 10
 
@@ -20,13 +20,18 @@ class EmailSubscriptionChooserMixin(ChooserMixin):
 
     def call_client(self, client):
         raise NotImplementedError(
-            "Implement a call_client method on the specific viewset"
+            "Implement a call_client method in the specific viewset"
         )
 
     def get_object_list(self, search_term=None, **kwargs):  # pylint: disable=W0221
         result = []
 
-        site = Site.find_for_request(self.request)
+        site_id = self.request.GET.get("site_id", None)
+        site = Site.objects.filter(id=site_id).first()
+
+        if site is None:
+            return result
+
         settings = get_email_subscription_settings(site)
 
         if settings.enabled:
@@ -53,16 +58,21 @@ class EmailSubscriptionChooserMixin(ChooserMixin):
     def get_object_string(self, item):  # pylint: disable=W0221
         return f"{item[self.title_field]}"
 
+    def get_choose_url(self):
+        choose_url = super().get_choose_url()
+        url_param = urlencode(self.request.GET)
+        return f"{choose_url}?{url_param}" if url_param else choose_url
+
+    def get_chosen_url(self, instance):
+        chosen_url = super().get_chosen_url(instance)
+        url_param = urlencode(self.request.GET)
+        return f"{chosen_url}?{url_param}" if url_param else chosen_url
+
 
 class EmailSubscriptionChooserViewSet(ChooserViewSet):
     chooser_mixin_class = EmailSubscriptionChooserMixin
 
     def update_attrs(self, attrs):
-        """
-        A django viewset is actually merging different views into a single view class
-        at runtime. So, what we do here is collecting the attributes and method of the mixin
-        classes and also set them on the runtime created view class.
-        """
         override_attributes = (
             "call_client",
             "filter_result_by_search_term",
@@ -86,8 +96,8 @@ class EmailSubscriptionChooserViewSet(ChooserViewSet):
 
     def get_urlpatterns(self):
         return [
-            url(r"^$", self.choose_view, name="choose"),
+            path("", self.choose_view, name="choose"),
             # we override this because our "id's" can also be slug
             # like values so we need a different regex here
-            url(r"^([-\w.]+)/$", self.chosen_view, name="chosen"),
-        ] + super().get_urlpatterns()
+            re_path(r"^([-\w.]+)/$", self.chosen_view, name="chosen"),
+        ]

--- a/src/wagtail_email_subscription/chooser/panels.py
+++ b/src/wagtail_email_subscription/chooser/panels.py
@@ -1,0 +1,8 @@
+from wagtail.admin.edit_handlers import FieldPanel
+
+from .widgets import ListChooserWidget
+
+
+class FieldPanelWithPage(FieldPanel):
+    def on_instance_bound(self):
+        self.widget = ListChooserWidget(page_instance=self.instance)

--- a/src/wagtail_email_subscription/chooser/widgets.py
+++ b/src/wagtail_email_subscription/chooser/widgets.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from django.core.exceptions import ObjectDoesNotExist
 from generic_chooser.widgets import AdminChooser
 
@@ -5,12 +7,22 @@ from generic_chooser.widgets import AdminChooser
 class EmailSubscriptionChooserWidget(AdminChooser):
     show_edit_link = False
 
+    def __init__(self, *args, **kwargs):
+        self.page_instance = kwargs.pop("page_instance", None)
+        super().__init__(*args, **kwargs)
+
     def get_instance(self, value):
         # value is the stored value, the value of a CharField or IntegerField
         # from a Django model
         if not value:
             raise ObjectDoesNotExist(str(value))
         return value
+
+    def get_choose_modal_url(self):
+        choose_modal_url = super().get_choose_modal_url()
+        site_id = self.page_instance.get_site().pk
+        url_param = urlencode({"site_id": site_id})
+        return f"{choose_modal_url}?{url_param}"
 
 
 class ListChooserWidget(EmailSubscriptionChooserWidget):


### PR DESCRIPTION
So we are sure we get the correct configuration for the clients in a multi-site environment